### PR TITLE
#94 - Support for alternative NameId policy

### DIFF
--- a/src/main/java/com/coveo/saml/SamlClient.java
+++ b/src/main/java/com/coveo/saml/SamlClient.java
@@ -104,6 +104,7 @@ public class SamlClient {
 
   private static final String HTTP_REQ_SAML_PARAM = "SAMLRequest";
   private static final String HTTP_RESP_SAML_PARAM = "SAMLResponse";
+  private static final String DEFAULT_NAMEID_POLICY_FORMAT = "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified";
 
   private static boolean initializedOpenSaml = false;
   private BasicParserPool domParser;
@@ -117,6 +118,7 @@ public class SamlClient {
   private String assertionConsumerServiceUrl;
   private String identityProviderUrl;
   private String responseIssuer;
+  private String nameIdPolicyFormat = DEFAULT_NAMEID_POLICY_FORMAT;
   private List<Credential> credentials;
   private DateTime now; // used for testing only
   private long notBeforeSkew = 0L;
@@ -155,6 +157,15 @@ public class SamlClient {
       throw new IllegalArgumentException("Skew must be non-negative");
     }
     this.notBeforeSkew = notBeforeSkew;
+  }
+
+  /**
+   * Set a {@link NameIDPolicy} format for the NameIDPolicy used in the {@link AuthnRequest}.
+   *
+   * @param nameIdPolicyFormat the NameIDPolicy format to use
+   */
+  public void setNameIdPolicyFormat(String nameIdPolicyFormat) {
+    this.nameIdPolicyFormat = nameIdPolicyFormat;
   }
 
   /**
@@ -780,7 +791,7 @@ public class SamlClient {
     request.setAssertionConsumerServiceURL(assertionConsumerServiceUrl);
 
     NameIDPolicy nameIDPolicy = (NameIDPolicy) buildSamlObject(NameIDPolicy.DEFAULT_ELEMENT_NAME);
-    nameIDPolicy.setFormat("urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified");
+    nameIDPolicy.setFormat(nameIdPolicyFormat);
     request.setNameIDPolicy(nameIDPolicy);
 
     signSAMLObject(request);

--- a/src/test/java/com/coveo/saml/SamlClientTest.java
+++ b/src/test/java/com/coveo/saml/SamlClientTest.java
@@ -115,6 +115,17 @@ public class SamlClientTest {
   }
 
   @Test
+  public void getSamlRequestReturnsAnEncodedRequestWithNameIDPolicy() throws Throwable {
+    SamlClient client =
+            SamlClient.fromMetadata(
+                    "myidentifier", "http://some/url", getXml("adfs.xml"), SamlClient.SamlIdpBinding.POST);
+    client.setNameIdPolicyFormat("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress");
+    String decoded =
+            new String(Base64.decodeBase64(client.getSamlRequest()), StandardCharsets.UTF_8);
+    assertTrue(decoded.contains("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"));
+  }
+
+  @Test
   public void decodeAndValidateSamlResponseCanDecodeAnSamlResponse() throws Throwable {
     SamlClient client =
         SamlClient.fromMetadata(


### PR DESCRIPTION
Add support for alternative name id policy, such as:
`urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`